### PR TITLE
优化 Arms 框架解析 AndroidManifext.xml 中的配置文件

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,8 +36,9 @@
             android:value="1920"/>
 
         <!-- arms配置 -->
-        <meta-data android:name="ARMS_MODULE_CONFIG"
-            android:value="me.jessyan.mvparms.demo.app.GlobalConfiguration"/>
+        <meta-data
+            android:name="me.jessyan.mvparms.demo.app.GlobalConfiguration"
+            android:value="ConfigModule"/>
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,9 +36,8 @@
             android:value="1920"/>
 
         <!-- arms配置 -->
-        <meta-data
-            android:name="me.jessyan.mvparms.demo.app.GlobalConfiguration"
-            android:value="ConfigModule"/>
+        <meta-data android:name="ARMS_MODULE_CONFIG"
+            android:value="me.jessyan.mvparms.demo.app.GlobalConfiguration"/>
 
     </application>
 

--- a/arms/src/main/java/com/jess/arms/integration/ManifestParser.java
+++ b/arms/src/main/java/com/jess/arms/integration/ManifestParser.java
@@ -35,7 +35,7 @@ import java.util.List;
  * ================================================
  */
 public final class ManifestParser {
-    private static final String MODULE_VALUE = "ARMS_MODULE_CONFIG";
+    private static final String MODULE_VALUE = "ConfigModule";
 
     private final Context context;
 
@@ -50,22 +50,20 @@ public final class ManifestParser {
                     context.getPackageName(), PackageManager.GET_META_DATA);
             if (appInfo.metaData != null) {
                 for (String key : appInfo.metaData.keySet()) {
-                    if(MODULE_VALUE.equals(key)) {
+                    String configModuleName = appInfo.metaData.get(key).toString();
+                    if(!TextUtils.isEmpty(configModuleName) && MODULE_VALUE.equals(configModuleName)) {
                         try {
-                            String className = appInfo.metaData.get(key).toString();
-                            if(!TextUtils.isEmpty(className)) {
-                                Class<?> clazz = Class.forName(className);
-                                for(Class clazzInter : clazz.getInterfaces()) {
-                                    if("com.jess.arms.integration.ConfigModule".equals(clazzInter.getName())) {
-                                        modules.add(parseModule(clazz));
-                                    }
+                            Class<?> clazz = Class.forName(key);
+                            for(Class clazzInter : clazz.getInterfaces()) {
+                                if("com.jess.arms.integration.ConfigModule".equals(clazzInter.getName())) {
+                                    modules.add(parseModule(clazz));
                                 }
-                            } else {
-                                Log.w("ManifestParser", "module config value cannot be null in AndroidManifest,xml");
                             }
                         } catch (ClassNotFoundException e) {
                             Log.w("ManifestParser", "Unable to find module config class");
                         }
+                    }else {
+                        Log.w("ManifestParser", "module config value cannot be null in AndroidManifest,xml");
                     }
                 }
             }

--- a/arms/src/main/java/com/jess/arms/integration/ManifestParser.java
+++ b/arms/src/main/java/com/jess/arms/integration/ManifestParser.java
@@ -61,10 +61,10 @@ public final class ManifestParser {
                                     }
                                 }
                             } else {
-                                throw new RuntimeException("module config value cannot be null in AndroidManifest,xml");
+                                Log.w("ManifestParser", "module config value cannot be null in AndroidManifest,xml");
                             }
                         } catch (ClassNotFoundException e) {
-                            throw new RuntimeException("Unable to find module config class", e);
+                            Log.w("ManifestParser", "Unable to find module config class");
                         }
                     }
                 }


### PR DESCRIPTION
优化了从 <meta-data> 解析 ConfigModule 配置文件

优化前的逻辑：
取出<meta-data> 数据，判断 value 字符串是否等于 ConfigModule，然后通过反射去实例化类，我觉得这里存在点小优化，<meta-data> 里的数据是开发者任意填写，如果填写的 value 是 ConfigModule, 单并未实现 ConfigModule 接口，而框架就是实例化了这个类，再去判断是否是 ConfigModule 的实例，结果可能不是，这里 cpu 也就做了些无用功。

优化后的逻辑：
优化点，先判断类是否实现了com.jess.arms.integration.ConfigModule接口，这样能100%是自己框架的东西，然后再去实例化，只是个小优化点

顺便优化了<meta-data> 的key和value的命名  key是唯一的：key=ARMS_MODULE_CONFIG, value 存放配置类名 ，例如 value= "me.jessyan.mvparms.demo.app.GlobalConfiguration"

