### PR TITLE
improve RepositoryManager.class

### DIFF
--- a/arms/src/main/java/com/jess/arms/integration/FragmentLifecycle.java
+++ b/arms/src/main/java/com/jess/arms/integration/FragmentLifecycle.java
@@ -21,18 +21,14 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.view.View;
-
 import com.jess.arms.base.delegate.FragmentDelegate;
 import com.jess.arms.base.delegate.FragmentDelegateImpl;
 import com.jess.arms.base.delegate.IFragment;
 import com.jess.arms.integration.cache.Cache;
 import com.jess.arms.integration.cache.IntelligentCache;
 import com.jess.arms.utils.Preconditions;
-
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import timber.log.Timber;
 
 /**
  * ================================================
@@ -53,7 +49,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentAttached(FragmentManager fm, Fragment f, Context context) {
-        Timber.w(f.toString() + " - onFragmentAttached");
         if (f instanceof IFragment) {
             FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
             if (fragmentDelegate == null || !fragmentDelegate.isAdded()) {
@@ -69,7 +64,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {
-        Timber.w(f.toString() + " - onFragmentCreated");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onCreate(savedInstanceState);
@@ -78,7 +72,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentViewCreated(FragmentManager fm, Fragment f, View v, Bundle savedInstanceState) {
-        Timber.w(f.toString() + " - onFragmentViewCreated");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onCreateView(v, savedInstanceState);
@@ -87,7 +80,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentActivityCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {
-        Timber.w(f.toString() + " - onFragmentActivityCreated");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onActivityCreate(savedInstanceState);
@@ -96,7 +88,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentStarted(FragmentManager fm, Fragment f) {
-        Timber.w(f.toString() + " - onFragmentStarted");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onStart();
@@ -105,7 +96,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentResumed(FragmentManager fm, Fragment f) {
-        Timber.w(f.toString() + " - onFragmentResumed");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onResume();
@@ -114,7 +104,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentPaused(FragmentManager fm, Fragment f) {
-        Timber.w(f.toString() + " - onFragmentPaused");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onPause();
@@ -123,7 +112,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentStopped(FragmentManager fm, Fragment f) {
-        Timber.w(f.toString() + " - onFragmentStopped");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onStop();
@@ -132,7 +120,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentSaveInstanceState(FragmentManager fm, Fragment f, Bundle outState) {
-        Timber.w(f.toString() + " - onFragmentSaveInstanceState");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onSaveInstanceState(outState);
@@ -141,7 +128,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentViewDestroyed(FragmentManager fm, Fragment f) {
-        Timber.w(f.toString() + " - onFragmentViewDestroyed");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onDestroyView();
@@ -150,7 +136,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentDestroyed(FragmentManager fm, Fragment f) {
-        Timber.w(f.toString() + " - onFragmentDestroyed");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onDestroy();
@@ -159,7 +144,6 @@ public class FragmentLifecycle extends FragmentManager.FragmentLifecycleCallback
 
     @Override
     public void onFragmentDetached(FragmentManager fm, Fragment f) {
-        Timber.w(f.toString() + " - onFragmentDetached");
         FragmentDelegate fragmentDelegate = fetchFragmentDelegate(f);
         if (fragmentDelegate != null) {
             fragmentDelegate.onDetach();

--- a/arms/src/main/java/com/jess/arms/integration/RepositoryManager.java
+++ b/arms/src/main/java/com/jess/arms/integration/RepositoryManager.java
@@ -17,17 +17,20 @@ package com.jess.arms.integration;
 
 import android.app.Application;
 import android.content.Context;
-
+import android.support.annotation.Nullable;
 import com.jess.arms.integration.cache.Cache;
 import com.jess.arms.integration.cache.CacheType;
 import com.jess.arms.mvp.IModel;
 import com.jess.arms.utils.Preconditions;
-
+import dagger.Lazy;
+import io.reactivex.Observable;
+import io.reactivex.schedulers.Schedulers;
+import io.rx_cache2.internal.RxCache;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import dagger.Lazy;
-import io.rx_cache2.internal.RxCache;
 import retrofit2.Retrofit;
 
 /**
@@ -66,16 +69,59 @@ public class RepositoryManager implements IRepositoryManager {
      * @return
      */
     @Override
-    public synchronized <T> T obtainRetrofitService(Class<T> service) {
-        if (mRetrofitServiceCache == null)
-            mRetrofitServiceCache = mCachefactory.build(CacheType.RETROFIT_SERVICE_CACHE);
+    public  <T> T obtainRetrofitService(Class<T> service) {
+        return createWrapperService(service);
+    }
+
+
+    private <T> T createWrapperService(Class<T> serviceClass) {
+        // 通过二次代理，对 Retrofit 代理方法的调用包进新的 Observable 里在 io 线程执行。
+        return (T) Proxy.newProxyInstance(serviceClass.getClassLoader(),
+                new Class<?>[]{serviceClass}, new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, @Nullable Object[] args)
+                            throws Throwable {
+                        if (method.getReturnType() == Observable.class) {
+                            // 如果方法返回值是 Observable 的话，则包一层再返回
+                            return Observable.defer(() -> {
+                                final T service = getRetrofitService(serviceClass);
+                                // 执行真正的 Retrofit 动态代理的方法
+                                return ((Observable) getRetrofitMethod(service, method)
+                                        .invoke(service, args))
+                                        .subscribeOn(Schedulers.io()); })
+                                    .subscribeOn(Schedulers.single());
+                        }
+                        // 返回值不是 Observable 的话不处理
+                        final T service = getRetrofitService(serviceClass);
+                        return getRetrofitMethod(service, method).invoke(service, args);
+                    }
+                });
+    }
+
+    private <T> T getRetrofitService(Class<T> service) {
+        if (mRetrofitServiceCache == null) {
+            synchronized (this) {
+                if (mRetrofitServiceCache == null) {
+                    mRetrofitServiceCache = mCachefactory.build(CacheType.RETROFIT_SERVICE_CACHE);
+                }
+            }
+        }
         Preconditions.checkNotNull(mRetrofitServiceCache, "Cannot return null from a Cache.Factory#build(int) method");
+
         T retrofitService = (T) mRetrofitServiceCache.get(service.getCanonicalName());
         if (retrofitService == null) {
-            retrofitService = mRetrofit.get().create(service);
-            mRetrofitServiceCache.put(service.getCanonicalName(), retrofitService);
+            synchronized (service) {
+                if (retrofitService == null) {
+                    retrofitService = mRetrofit.get().create(service);
+                    mRetrofitServiceCache.put(service.getCanonicalName(), retrofitService);
+                }
+            }
         }
         return retrofitService;
+    }
+
+    private <T> Method getRetrofitMethod(T service, Method method) throws NoSuchMethodException {
+        return service.getClass().getMethod(method.getName(), method.getParameterTypes());
     }
 
     /**
@@ -86,14 +132,24 @@ public class RepositoryManager implements IRepositoryManager {
      * @return
      */
     @Override
-    public synchronized <T> T obtainCacheService(Class<T> cache) {
-        if (mCacheServiceCache == null)
-            mCacheServiceCache = mCachefactory.build(CacheType.CACHE_SERVICE_CACHE);
+    public  <T> T obtainCacheService(Class<T> cache) {
+        if (mCacheServiceCache == null) {
+            synchronized (this) {
+                if (mCacheServiceCache == null) {
+                    mCacheServiceCache = mCachefactory.build(CacheType.CACHE_SERVICE_CACHE);
+                }
+            }
+        }
         Preconditions.checkNotNull(mCacheServiceCache, "Cannot return null from a Cache.Factory#build(int) method");
+
         T cacheService = (T) mCacheServiceCache.get(cache.getCanonicalName());
         if (cacheService == null) {
-            cacheService = mRxCache.get().using(cache);
-            mCacheServiceCache.put(cache.getCanonicalName(), cacheService);
+            synchronized (cache) {
+                if (cacheService == null) {
+                    cacheService = mRxCache.get().using(cache);
+                    mCacheServiceCache.put(cache.getCanonicalName(), cacheService);
+                }
+            }
         }
         return cacheService;
     }

--- a/demo/src/main/java/me/jessyan/mvparms/demo/app/ActivityLifecycleCallbacksImpl.java
+++ b/demo/src/main/java/me/jessyan/mvparms/demo/app/ActivityLifecycleCallbacksImpl.java
@@ -39,12 +39,12 @@ public class ActivityLifecycleCallbacksImpl implements Application.ActivityLifec
 
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-        Timber.w(activity + " - onActivityCreated");
+        Timber.i(activity + " - onActivityCreated");
     }
 
     @Override
     public void onActivityStarted(Activity activity) {
-        Timber.w(activity + " - onActivityStarted");
+        Timber.i(activity + " - onActivityStarted");
         if (!activity.getIntent().getBooleanExtra("isInitToolbar", false)) {
             //由于加强框架的兼容性,故将 setContentView 放到 onActivityCreated 之后,onActivityStarted 之前执行
             //而 findViewById 必须在 Activity setContentView() 后才有效,所以将以下代码从之前的 onActivityCreated 中移动到 onActivityStarted 中执行
@@ -74,27 +74,27 @@ public class ActivityLifecycleCallbacksImpl implements Application.ActivityLifec
 
     @Override
     public void onActivityResumed(Activity activity) {
-        Timber.w(activity + " - onActivityResumed");
+        Timber.i(activity + " - onActivityResumed");
     }
 
     @Override
     public void onActivityPaused(Activity activity) {
-        Timber.w(activity + " - onActivityPaused");
+        Timber.i(activity + " - onActivityPaused");
     }
 
     @Override
     public void onActivityStopped(Activity activity) {
-        Timber.w(activity + " - onActivityStopped");
+        Timber.i(activity + " - onActivityStopped");
     }
 
     @Override
     public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-        Timber.w(activity + " - onActivitySaveInstanceState");
+        Timber.i(activity + " - onActivitySaveInstanceState");
     }
 
     @Override
     public void onActivityDestroyed(Activity activity) {
-        Timber.w(activity + " - onActivityDestroyed");
+        Timber.i(activity + " - onActivityDestroyed");
         //横竖屏切换或配置改变时, Activity 会被重新创建实例, 但 Bundle 中的基础数据会被保存下来,移除该数据是为了保证重新创建的实例可以正常工作
         activity.getIntent().removeExtra("isInitToolbar");
     }

--- a/demo/src/main/java/me/jessyan/mvparms/demo/app/FragmentLifecycleCallbacksImpl.java
+++ b/demo/src/main/java/me/jessyan/mvparms/demo/app/FragmentLifecycleCallbacksImpl.java
@@ -1,0 +1,93 @@
+package me.jessyan.mvparms.demo.app;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.view.View;
+import com.jess.arms.integration.cache.IntelligentCache;
+import com.jess.arms.utils.ArmsUtils;
+import com.squareup.leakcanary.RefWatcher;
+import timber.log.Timber;
+
+/**
+ * ================================================
+ * 展示 {@link FragmentManager.FragmentLifecycleCallbacks} 的用法
+ * <p>
+ * Created by JessYan on 23/08/2018 17:14
+ * <a href="mailto:jess.yan.effort@gmail.com">Contact me</a>
+ * <a href="https://github.com/JessYanCoding">Follow me</a>
+ * ================================================
+ */
+public class FragmentLifecycleCallbacksImpl extends FragmentManager.FragmentLifecycleCallbacks{
+
+    @Override
+    public void onFragmentAttached(FragmentManager fm, Fragment f, Context context) {
+        Timber.i(f.toString() + " - onFragmentAttached");
+    }
+
+    @Override
+    public void onFragmentCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {
+        Timber.i(f.toString() + " - onFragmentCreated");
+        // 在配置变化的时候将这个 Fragment 保存下来,在 Activity 由于配置变化重建时重复利用已经创建的 Fragment。
+        // https://developer.android.com/reference/android/app/Fragment.html?hl=zh-cn#setRetainInstance(boolean)
+        // 如果在 XML 中使用 <Fragment/> 标签,的方式创建 Fragment 请务必在标签中加上 android:id 或者 android:tag 属性,否则 setRetainInstance(true) 无效
+        // 在 Activity 中绑定少量的 Fragment 建议这样做,如果需要绑定较多的 Fragment 不建议设置此参数,如 ViewPager 需要展示较多 Fragment
+        f.setRetainInstance(true);
+    }
+
+    @Override
+    public void onFragmentViewCreated(FragmentManager fm, Fragment f, View v, Bundle savedInstanceState) {
+        Timber.i(f.toString() + " - onFragmentViewCreated");
+    }
+
+    @Override
+    public void onFragmentActivityCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {
+        Timber.i(f.toString() + " - onFragmentActivityCreated");
+    }
+
+    @Override
+    public void onFragmentStarted(FragmentManager fm, Fragment f) {
+        Timber.i(f.toString() + " - onFragmentStarted");
+    }
+
+    @Override
+    public void onFragmentResumed(FragmentManager fm, Fragment f) {
+        Timber.i(f.toString() + " - onFragmentResumed");
+    }
+
+    @Override
+    public void onFragmentPaused(FragmentManager fm, Fragment f) {
+        Timber.i(f.toString() + " - onFragmentPaused");
+    }
+
+    @Override
+    public void onFragmentStopped(FragmentManager fm, Fragment f) {
+        Timber.i(f.toString() + " - onFragmentStopped");
+    }
+
+    @Override
+    public void onFragmentSaveInstanceState(FragmentManager fm, Fragment f, Bundle outState) {
+        Timber.i(f.toString() + " - onFragmentSaveInstanceState");
+    }
+
+    @Override
+    public void onFragmentViewDestroyed(FragmentManager fm, Fragment f) {
+        Timber.i(f.toString() + " - onFragmentViewDestroyed");
+    }
+
+    @Override
+    public void onFragmentDestroyed(FragmentManager fm, Fragment f) {
+        Timber.i(f.toString() + " - onFragmentDestroyed");
+        ((RefWatcher) ArmsUtils
+                .obtainAppComponentFromContext(f.getActivity())
+                .extras()
+                .get(IntelligentCache.getKeyOfKeep(RefWatcher.class.getName())))
+                .watch(f);
+    }
+
+    @Override
+    public void onFragmentDetached(FragmentManager fm, Fragment f) {
+        Timber.i(f.toString() + " - onFragmentDetached");
+    }
+}

--- a/demo/src/main/java/me/jessyan/mvparms/demo/app/FragmentLifecycleCallbacksImpl.java
+++ b/demo/src/main/java/me/jessyan/mvparms/demo/app/FragmentLifecycleCallbacksImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 JessYan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package me.jessyan.mvparms.demo.app;
 
 import android.content.Context;

--- a/demo/src/main/java/me/jessyan/mvparms/demo/app/GlobalConfiguration.java
+++ b/demo/src/main/java/me/jessyan/mvparms/demo/app/GlobalConfiguration.java
@@ -17,22 +17,14 @@ package me.jessyan.mvparms.demo.app;
 
 import android.app.Application;
 import android.content.Context;
-import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-
 import com.jess.arms.base.delegate.AppLifecycles;
 import com.jess.arms.di.module.GlobalConfigModule;
 import com.jess.arms.http.imageloader.glide.GlideImageLoaderStrategy;
 import com.jess.arms.http.log.RequestInterceptor;
 import com.jess.arms.integration.ConfigModule;
-import com.jess.arms.integration.cache.IntelligentCache;
-import com.jess.arms.utils.ArmsUtils;
-import com.squareup.leakcanary.RefWatcher;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import me.jessyan.mvparms.demo.BuildConfig;
 import me.jessyan.mvparms.demo.mvp.model.api.Api;
 import me.jessyan.progressmanager.ProgressManager;
@@ -168,26 +160,7 @@ public final class GlobalConfiguration implements ConfigModule {
 
     @Override
     public void injectFragmentLifecycle(Context context, List<FragmentManager.FragmentLifecycleCallbacks> lifecycles) {
-        lifecycles.add(new FragmentManager.FragmentLifecycleCallbacks() {
-
-            @Override
-            public void onFragmentCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {
-                // 在配置变化的时候将这个 Fragment 保存下来,在 Activity 由于配置变化重建时重复利用已经创建的 Fragment。
-                // https://developer.android.com/reference/android/app/Fragment.html?hl=zh-cn#setRetainInstance(boolean)
-                // 如果在 XML 中使用 <Fragment/> 标签,的方式创建 Fragment 请务必在标签中加上 android:id 或者 android:tag 属性,否则 setRetainInstance(true) 无效
-                // 在 Activity 中绑定少量的 Fragment 建议这样做,如果需要绑定较多的 Fragment 不建议设置此参数,如 ViewPager 需要展示较多 Fragment
-                f.setRetainInstance(true);
-            }
-
-            @Override
-            public void onFragmentDestroyed(FragmentManager fm, Fragment f) {
-                ((RefWatcher) ArmsUtils
-                        .obtainAppComponentFromContext(f.getActivity())
-                        .extras()
-                        .get(IntelligentCache.getKeyOfKeep(RefWatcher.class.getName())))
-                        .watch(f);
-            }
-        });
+        lifecycles.add(new FragmentLifecycleCallbacksImpl());
     }
 
 }


### PR DESCRIPTION
Retrofit的代理方法的调用（被观察者的构建）一般在 main 线程，且Retrofit的代理方法的内容较为耗时，通过二次代理相对明显的优化便是app启动速度的优化（如果有广告页的话），其次在初次构造ServiceMethod时，不阻塞 main线程。
另一个提交是，修改Activity和fragment的日志输出级别为i，且将fragment的日志打印选择提供出去给框架使用者。