### PR TITLE
Update proguard-rules.pro

### DIFF
--- a/arms/proguard-rules.pro
+++ b/arms/proguard-rules.pro
@@ -135,6 +135,7 @@
 -keepclassmembers class * {
     @org.greenrobot.eventbus.Subscribe <methods>;
 }
+-keep class org.greenrobot.eventbus.EventBus { *; }
 -keep enum org.greenrobot.eventbus.ThreadMode { *; }
 
 -keepclassmembers class * extends org.greenrobot.eventbus.util.ThrowableFailureEvent {


### PR DESCRIPTION
更新EventBus混淆配置，保持org.greenrobot.eventbus.EventBus不被混淆，因为Platform当中引用该类全类名字符串，如果被混淆DEPENDENCY_EVENTBUS将失去效果