### PR TITLE
1，完成委托创建服务的代码调整

### DIFF
--- a/arms/src/main/java/com/jess/arms/integration/IRepositoryManager.java
+++ b/arms/src/main/java/com/jess/arms/integration/IRepositoryManager.java
@@ -17,8 +17,11 @@ package com.jess.arms.integration;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.jess.arms.mvp.IModel;
+
+import retrofit2.Retrofit;
 
 /**
  * ================================================
@@ -66,4 +69,17 @@ public interface IRepositoryManager {
      */
     @NonNull
     Context getContext();
+
+    /**
+     * 设置一个可以委托创建服务的接口
+     *
+     * @param delegate 委托接口，可为空
+     */
+    void setObtainServiceDelegate(@Nullable ObtainServiceDelegate delegate);
+
+    interface ObtainServiceDelegate {
+
+        @Nullable
+        <T> T createRetrofitService(Retrofit retrofit, Class<T> serviceClass);
+    }
 }

--- a/arms/src/main/java/com/jess/arms/integration/RetrofitServiceProxyHandler.java
+++ b/arms/src/main/java/com/jess/arms/integration/RetrofitServiceProxyHandler.java
@@ -1,0 +1,55 @@
+package com.jess.arms.integration;
+
+import android.support.annotation.Nullable;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import retrofit2.Retrofit;
+
+
+public class RetrofitServiceProxyHandler implements InvocationHandler {
+
+    private Retrofit mRetrofit;
+    private Class<?> mServiceClass;
+    private Object mRetrofitService;
+
+    public RetrofitServiceProxyHandler(Retrofit retrofit, Class<?> serviceClass) {
+        mRetrofit = retrofit;
+        mServiceClass = serviceClass;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
+
+        // 根据 https://zhuanlan.zhihu.com/p/40097338 对 Retrofit 进行的优化
+
+        if (method.getReturnType() == Observable.class) {
+            // 如果方法返回值是 Observable 的话，则包一层再返回，
+            // 只包一层 defer 由外部去控制耗时方法以及网络请求所处线程，
+            // 如此对原项目的影响为 0，且更可控。
+            return Observable.defer(() -> {
+                // 执行真正的 Retrofit 动态代理的方法
+                return (Observable) method.invoke(getRetrofitService(), args);
+            });
+        } else if (method.getReturnType() == Single.class) {
+            // 如果方法返回值是 Single 的话，则包一层再返回。
+            return Single.defer(() -> {
+                // 执行真正的 Retrofit 动态代理的方法
+                return (Single) method.invoke(getRetrofitService(), args);
+            });
+        }
+
+        // 返回值不是 Observable 或 Single 的话不处理。
+        return method.invoke(getRetrofitService(), args);
+    }
+
+    private Object getRetrofitService() {
+        if (mRetrofitService == null) {
+            mRetrofitService = mRetrofit.create(mServiceClass);
+        }
+        return mRetrofitService;
+    }
+}


### PR DESCRIPTION
主要修改为在IRepositoryManager接口中增加一套委托机制，说明如下
1，如果不使用这套委托机制创建RetrofitService，不会影响框架原有的功能
2，开放RetrofitService的委托创建，方便开发者参考二次委托代理的方法，在某些请求接口执行前自行处理一些事情，增加框架的灵活度
3，可以遇到的应用场景，即在每次调用网络请求接口时，使用RetrofitUrlManager设置baseUrl，防止程序中的一些崩溃，导致RetrofitUrlManager中存储的domain信息丢失