### PR TITLE
Update GlideAppliesOptions & IRepositoryManager

### DIFF
--- a/arms-imageloader-glide/src/main/java/com/jess/arms/http/imageloader/glide/GlideImageLoaderStrategy.java
+++ b/arms-imageloader-glide/src/main/java/com/jess/arms/http/imageloader/glide/GlideImageLoaderStrategy.java
@@ -23,6 +23,7 @@ import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.GlideBuilder;
+import com.bumptech.glide.Registry;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
@@ -157,5 +158,10 @@ public class GlideImageLoaderStrategy implements BaseImageLoaderStrategy<ImageCo
     @Override
     public void applyGlideOptions(@NonNull Context context, @NonNull GlideBuilder builder) {
         Timber.i("applyGlideOptions");
+    }
+
+    @Override
+    public void registerComponents(@NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
+        Timber.i("registerComponents");
     }
 }

--- a/arms/src/main/java/com/jess/arms/di/module/GlobalConfigModule.java
+++ b/arms/src/main/java/com/jess/arms/di/module/GlobalConfigModule.java
@@ -27,6 +27,7 @@ import com.jess.arms.http.imageloader.BaseImageLoaderStrategy;
 import com.jess.arms.http.log.DefaultFormatPrinter;
 import com.jess.arms.http.log.FormatPrinter;
 import com.jess.arms.http.log.RequestInterceptor;
+import com.jess.arms.integration.IRepositoryManager;
 import com.jess.arms.integration.cache.Cache;
 import com.jess.arms.integration.cache.CacheType;
 import com.jess.arms.integration.cache.IntelligentCache;
@@ -79,6 +80,7 @@ public class GlobalConfigModule {
     private FormatPrinter mFormatPrinter;
     private Cache.Factory mCacheFactory;
     private ExecutorService mExecutorService;
+    private IRepositoryManager.ObtainServiceDelegate mObtainServiceDelegate;
 
     private GlobalConfigModule(Builder builder) {
         this.mApiUrl = builder.apiUrl;
@@ -96,6 +98,7 @@ public class GlobalConfigModule {
         this.mFormatPrinter = builder.formatPrinter;
         this.mCacheFactory = builder.cacheFactory;
         this.mExecutorService = builder.executorService;
+        this.mObtainServiceDelegate = builder.obtainServiceDelegate;
     }
 
     public static Builder builder() {
@@ -246,6 +249,13 @@ public class GlobalConfigModule {
                 new SynchronousQueue<Runnable>(), Util.threadFactory("Arms Executor", false)) : mExecutorService;
     }
 
+    @Singleton
+    @Provides
+    @Nullable
+    IRepositoryManager.ObtainServiceDelegate provideObtainServiceDelegate() {
+        return mObtainServiceDelegate;
+    }
+
     public static final class Builder {
         private HttpUrl apiUrl;
         private BaseUrl baseUrl;
@@ -262,6 +272,7 @@ public class GlobalConfigModule {
         private FormatPrinter formatPrinter;
         private Cache.Factory cacheFactory;
         private ExecutorService executorService;
+        private IRepositoryManager.ObtainServiceDelegate obtainServiceDelegate;
 
         private Builder() {
         }
@@ -343,6 +354,11 @@ public class GlobalConfigModule {
 
         public Builder executorService(ExecutorService executorService) {
             this.executorService = executorService;
+            return this;
+        }
+
+        public Builder obtainServiceDelegate(IRepositoryManager.ObtainServiceDelegate obtainServiceDelegate) {
+            this.obtainServiceDelegate = obtainServiceDelegate;
             return this;
         }
 

--- a/arms/src/main/java/com/jess/arms/http/imageloader/glide/GlideAppliesOptions.java
+++ b/arms/src/main/java/com/jess/arms/http/imageloader/glide/GlideAppliesOptions.java
@@ -20,6 +20,7 @@ import android.support.annotation.NonNull;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.GlideBuilder;
+import com.bumptech.glide.Registry;
 import com.jess.arms.http.imageloader.BaseImageLoaderStrategy;
 
 /**
@@ -41,4 +42,13 @@ public interface GlideAppliesOptions {
      * @param builder {@link GlideBuilder} 此类被用来创建 Glide
      */
     void applyGlideOptions(@NonNull Context context, @NonNull GlideBuilder builder);
+
+    /**
+     * 注册{@link Glide}的组件，参考{@link com.bumptech.glide.module.LibraryGlideModule}
+     *
+     * @param context  Android context
+     * @param glide    {@link Glide}
+     * @param registry {@link Registry}
+     */
+    void registerComponents(@NonNull Context context, @NonNull Glide glide, @NonNull Registry registry);
 }

--- a/arms/src/main/java/com/jess/arms/http/imageloader/glide/GlideConfiguration.java
+++ b/arms/src/main/java/com/jess/arms/http/imageloader/glide/GlideConfiguration.java
@@ -32,8 +32,8 @@ import com.bumptech.glide.module.AppGlideModule;
 import com.jess.arms.di.component.AppComponent;
 import com.jess.arms.http.OkHttpUrlLoader;
 import com.jess.arms.http.imageloader.BaseImageLoaderStrategy;
-import com.jess.arms.utils.DataHelper;
 import com.jess.arms.utils.ArmsUtils;
+import com.jess.arms.utils.DataHelper;
 
 import java.io.File;
 import java.io.InputStream;
@@ -77,7 +77,7 @@ public class GlideConfiguration extends AppGlideModule {
         //并不能满足自己的需求,想自定义 BaseImageLoaderStrategy,那请你最好实现 GlideAppliesOptions
         //因为只有成为 GlideAppliesOptions 的实现类,这里才能调用 applyGlideOptions(),让你具有配置 Glide 的权利
         BaseImageLoaderStrategy loadImgStrategy = appComponent.imageLoader().getLoadImgStrategy();
-        if (loadImgStrategy != null && loadImgStrategy instanceof GlideAppliesOptions) {
+        if (loadImgStrategy instanceof GlideAppliesOptions) {
             ((GlideAppliesOptions) loadImgStrategy).applyGlideOptions(context, builder);
         }
     }
@@ -87,6 +87,11 @@ public class GlideConfiguration extends AppGlideModule {
         //Glide 默认使用 HttpURLConnection 做网络请求,在这切换成 Okhttp 请求
         AppComponent appComponent = ArmsUtils.obtainAppComponentFromContext(context);
         registry.replace(GlideUrl.class, InputStream.class, new OkHttpUrlLoader.Factory(appComponent.okHttpClient()));
+
+        BaseImageLoaderStrategy loadImgStrategy = appComponent.imageLoader().getLoadImgStrategy();
+        if (loadImgStrategy instanceof GlideAppliesOptions) {
+            ((GlideAppliesOptions) loadImgStrategy).registerComponents(context, glide, registry);
+        }
     }
 
     @Override

--- a/arms/src/main/java/com/jess/arms/integration/IRepositoryManager.java
+++ b/arms/src/main/java/com/jess/arms/integration/IRepositoryManager.java
@@ -70,13 +70,6 @@ public interface IRepositoryManager {
     @NonNull
     Context getContext();
 
-    /**
-     * 设置一个可以委托创建服务的接口
-     *
-     * @param delegate 委托接口，可为空
-     */
-    void setObtainServiceDelegate(@Nullable ObtainServiceDelegate delegate);
-
     interface ObtainServiceDelegate {
 
         @Nullable

--- a/arms/src/main/java/com/jess/arms/integration/RepositoryManager.java
+++ b/arms/src/main/java/com/jess/arms/integration/RepositoryManager.java
@@ -57,9 +57,11 @@ public class RepositoryManager implements IRepositoryManager {
     Application mApplication;
     @Inject
     Cache.Factory mCacheFactory;
+    @Inject
+    @Nullable
+    ObtainServiceDelegate mObtainServiceDelegate;
     private Cache<String, Object> mRetrofitServiceCache;
     private Cache<String, Object> mCacheServiceCache;
-    private ObtainServiceDelegate mDelegate;
 
     @Inject
     public RepositoryManager() {
@@ -82,8 +84,9 @@ public class RepositoryManager implements IRepositoryManager {
                 "Cannot return null from a Cache.Factory#build(int) method");
         T retrofitService = (T) mRetrofitServiceCache.get(serviceClass.getCanonicalName());
         if (retrofitService == null) {
-            if (mDelegate != null) {
-                retrofitService = mDelegate.createRetrofitService(mRetrofit.get(), serviceClass);
+            if (mObtainServiceDelegate != null) {
+                retrofitService = mObtainServiceDelegate.createRetrofitService(
+                        mRetrofit.get(), serviceClass);
             }
             if (retrofitService == null) {
                 retrofitService = (T) Proxy.newProxyInstance(
@@ -132,10 +135,5 @@ public class RepositoryManager implements IRepositoryManager {
     @Override
     public Context getContext() {
         return mApplication;
-    }
-
-    @Override
-    public void setObtainServiceDelegate(@Nullable ObtainServiceDelegate delegate) {
-        mDelegate = delegate;
     }
 }


### PR DESCRIPTION
主要修改有两处：
1，IRepositoryManager中去除setObtainServiceDelegate方法，转为GlobalConfigModule.Builder中统一配置
2，GlideAppliesOptions中增加registerComponents方法，当使用Glide的时候给第三方开发者提供了一个可以自定义GlideUrl的获取方式
我在项目中遇到这样的情况，在GET图片的时候需要根据图片url在header中动态添加一个数据，此时Okhttp的Interceptor不太好处理，增加registerComponents可以把整个请求的网络请求的框架委托出去，给开发者自定义，而无需修改MVPArms的源码