### PR TITLE
增加对RetrofitService缓存的清理

### DIFF
--- a/arms/src/main/java/com/jess/arms/integration/IRepositoryManager.java
+++ b/arms/src/main/java/com/jess/arms/integration/IRepositoryManager.java
@@ -63,6 +63,11 @@ public interface IRepositoryManager {
     void clearAllCache();
 
     /**
+     * 清理Retrofit的缓存
+     */
+    void clearRetrofitCache();
+
+    /**
      * 获取 {@link Context}
      *
      * @return {@link Context}

--- a/arms/src/main/java/com/jess/arms/integration/RepositoryManager.java
+++ b/arms/src/main/java/com/jess/arms/integration/RepositoryManager.java
@@ -131,6 +131,16 @@ public class RepositoryManager implements IRepositoryManager {
         mRxCache.get().evictAll().subscribe();
     }
 
+    /**
+     * 清理RetrofitService的缓存
+     */
+    @Override
+    public void clearRetrofitCache() {
+        if (mRetrofitServiceCache != null) {
+            mRetrofitServiceCache.clear();
+        }
+    }
+
     @NonNull
     @Override
     public Context getContext() {


### PR DESCRIPTION
1.RepositoryManager中创建RetrofitService会放在缓存里，如果用户不退出应用，退回到登录界面再次切换BaseUrl，此时RetrofitUrlManager.putDomain不会生效，因为obtainRetrofitService里会直接从缓存拿已创建的RetrofitService。
2.所以这里提供一个可用用户清理Retrofit缓存的方法