### PR TITLE
fix XX_MembersInjector is repeatedly generated in multi-module

### DIFF
--- a/arms/src/main/java/com/jess/arms/base/BaseLazyLoadFragment.java
+++ b/arms/src/main/java/com/jess/arms/base/BaseLazyLoadFragment.java
@@ -7,10 +7,15 @@ import com.jess.arms.mvp.IPresenter;
 
 import java.util.List;
 
+import javax.inject.Inject;
+
 /**
  * 子类覆写{@link BaseLazyLoadFragment}lazyLoadData可快速实现Fragment懒加载
  */
 public abstract class BaseLazyLoadFragment<P extends IPresenter> extends BaseFragment<P> {
+
+    @Inject
+    Unused mUnused;
 
     private boolean isViewCreated; // 界面是否已创建完成
     private boolean isVisibleToUser; // 是否对用户可见

--- a/arms/src/main/java/com/jess/arms/base/Unused.java
+++ b/arms/src/main/java/com/jess/arms/base/Unused.java
@@ -1,0 +1,14 @@
+package com.jess.arms.base;
+
+import javax.inject.Inject;
+
+/**
+ * Created by yexiaokang on 2019/11/12.
+ */
+public class Unused {
+
+    @Inject
+    public Unused() {
+
+    }
+}


### PR DESCRIPTION
项目中base目录下增加了一个 BaseLazyLoadFragment，目的是为了给各个子module引用，但是因为需要使用Dagger来生成XX_MembersInjector，所以引发了如下一个问题：如果有两个子模块同时引用BaseLazyLoadFragment，则会在每个子模块中都生成一份BaseLazyLoadFragment_MembersInjector，导致打包时因为重复的类而无法打包， https://github.com/JessYanCoding/ArmsComponent/issues/25 也提到了这个问题

经过各种查找问题，这是Google dagger机制的问题，主要解决方案才考如下路径：https://github.com/google/dagger/issues/955

当一个中间类（BaseLazyLoadFragment）不需要inject操作的时候，dagger不会为它在base module中生成BaseLazyLoadFragment_MembersInjector，当其他依赖的子模块使用到BaseLazyLoadFragment时，没找到MembersInjector类，就在每个模块中自行生成了，最终在打包APP时，由于重复生成的MembersInjector类，会导致打包失败
解决方案就如merge的代码一样，手动添加一个无用的inject字段，来触发dagger在编译时为base module生成对应的MembersInjector类，这样每个引用的模块中就不会重复生成

对于Dagger而言，如果中间类（BaseLazyLoadFragment）不需要inject操作，dagger不会知道它的存在，也就不会生成MembersInjector类，除非有上下文的引用